### PR TITLE
Refer to http://man7.org/linux/man-pages/man7/user_namespaces.7.html …

### DIFF
--- a/nscon/configurator/user_ns_configurator.h
+++ b/nscon/configurator/user_ns_configurator.h
@@ -50,6 +50,7 @@ class UserNsConfigurator : public NsConfigurator {
   ::util::Status WriteIdMap(
       const string &id_map_path,
       const ::std::vector<IdMapEntry> &id_map) const;
+  ::util::Status ProcSetGroupsWrite(pid_t child_pid) const;
   ::util::Status SetupUserNamespace(const UserNsSpec &user_spec,
                                     pid_t init_pid) const;
   ::util::StatusOr<::std::vector<IdMapEntry>> ValidateIdMap(


### PR DESCRIPTION
…Linux 3.19 made a change in the handling of setgroups(2) and the

```
      'gid_map' file to address a security issue. The issue allowed
      *unprivileged* users to employ user namespaces in order to drop
      The upshot of the 3.19 changes is that in order to update the
      'gid_maps' file, use of the setgroups() system call in this
      user namespace must first be disabled by writing deny to one of
      the /proc/PID/setgroups files for this namespace.  That is the
      purpose of the following function.
```
